### PR TITLE
Add fen headers to openings sheet

### DIFF
--- a/fen_backfill.gs
+++ b/fen_backfill.gs
@@ -187,19 +187,21 @@ function FEN_getOrCreateTargetSheetEnsuringFenHeaders_() {
     sheet.setFrozenRows(1);
   }
 
-  // Ensure FEN-related columns are present; append any that are missing
+  // Ensure FEN-related columns are present; append any that are missing to the far right
   var required = [
     'FEN','FEN_board','FEN_active','FEN_castle','FEN_ep','FEN_halfmove','FEN_fullmove',
     'FEN_r8','FEN_r7','FEN_r6','FEN_r5','FEN_r4','FEN_r3','FEN_r2','FEN_r1'
   ];
 
-  var currentHeaders = sheet.getRange(1, 1, 1, sheet.getLastColumn() || 1).getValues()[0];
+  var lastCol = sheet.getLastColumn() || 1;
+  var currentHeaders = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  var missing = [];
   for (var i = 0; i < required.length; i++) {
-    if (currentHeaders.indexOf(required[i]) === -1) {
-      sheet.insertColumnAfter(sheet.getLastColumn() || 1);
-      sheet.getRange(1, sheet.getLastColumn()).setValue(required[i]);
-      currentHeaders = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    }
+    if (currentHeaders.indexOf(required[i]) === -1) missing.push(required[i]);
+  }
+  if (missing.length) {
+    sheet.insertColumnsAfter(lastCol, missing.length);
+    sheet.getRange(1, lastCol + 1, 1, missing.length).setValues([missing]);
   }
 
   sheet.setFrozenRows(1);


### PR DESCRIPTION
Append missing FEN backfill headers as a single block to the far right of the `Openings Normalized` sheet.

The previous implementation inserted missing FEN headers one by one, which could lead to them being interspersed or not consistently at the very end of the existing data. This change collects all missing FEN headers first and then inserts them together, ensuring they always appear as a contiguous block to the right of all other data.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e9f8e15-2b57-433f-a20e-5e815f12f6cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e9f8e15-2b57-433f-a20e-5e815f12f6cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

